### PR TITLE
Add xdebug 3 support

### DIFF
--- a/7.2/scripts/install-development.sh
+++ b/7.2/scripts/install-development.sh
@@ -22,7 +22,7 @@ curl -LsS https://getcomposer.org/installer | \
     [[ -e Tideways.php ]] || false && true
 )
 
-printf "xdebug.remote_enable = 1\nxdebug.remote_connect_back = 1\nxdebug.max_nesting_level=400\n" \
+printf "xdebug.mode = develop,debug\nxdebug.discover_client_host = 1\nxdebug.max_nesting_level=400\n" \
     >> /etc/php/${DW_PHP_VERSION}/mods-available/xdebug.ini
 
 if [[ -e /etc/php/${DW_PHP_VERSION}/mods-available/tideways.ini ]]; then

--- a/7.3/scripts/install-development.sh
+++ b/7.3/scripts/install-development.sh
@@ -22,7 +22,7 @@ curl -LsS https://getcomposer.org/installer | \
     [[ -e Tideways.php ]] || false && true
 )
 
-printf "xdebug.remote_enable = 1\nxdebug.remote_connect_back = 1\nxdebug.max_nesting_level=400\n" \
+printf "xdebug.mode = develop,debug\nxdebug.discover_client_host = 1\nxdebug.max_nesting_level=400\n" \
     >> /etc/php/${DW_PHP_VERSION}/mods-available/xdebug.ini
 
 if [[ -e /etc/php/${DW_PHP_VERSION}/mods-available/tideways.ini ]]; then

--- a/7.4/scripts/install-development.sh
+++ b/7.4/scripts/install-development.sh
@@ -22,7 +22,7 @@ curl -LsS https://getcomposer.org/installer | \
     [[ -e Tideways.php ]] || false && true
 )
 
-printf "xdebug.remote_enable = 1\nxdebug.remote_connect_back = 1\nxdebug.max_nesting_level=400\n" \
+printf "xdebug.mode = develop,debug\nxdebug.discover_client_host = 1\nxdebug.max_nesting_level=400\n" \
     >> /etc/php/${DW_PHP_VERSION}/mods-available/xdebug.ini
 
 if [[ -e /etc/php/${DW_PHP_VERSION}/mods-available/tideways.ini ]]; then

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ connect back.
 example:
 
 ~~~ sh
-$ docker run -e DEVELOPMENT=1 -e "XDEBUG_CONFIG=remote_host=192.168.65.1" dockerwest/php:<version>
+$ docker run -e DEVELOPMENT=1 -e "XDEBUG_CONFIG=client_host=192.168.65.1" dockerwest/php:<version>
 ~~~
 
 ### PHP_EXTRA_MODULES


### PR DESCRIPTION
Update xdebug settings as described in upgrade guide: https://xdebug.org/docs/upgrade_guide

Missing features: profiling
Maybe the new "xdebug.mode" could be defined in the .env file, this way you can easily enable debugging and profiling. The default option could be "develop" 